### PR TITLE
Fix dirname pointing to node_module location

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 import { fileURLToPath } from 'url'
 import { dirname as path_dirname } from 'path'
 
-export default function dirname () {
-  var __filename = fileURLToPath(import.meta.url)
+export default function dirname (metaUrl) {
+  var __filename = fileURLToPath(metaUrl || import.meta.url)
   var __dirname = path_dirname(__filename)
   return __dirname
 }


### PR DESCRIPTION
Fixing this bug by actually using the parameter passed to the module and resolving that to the dirname.